### PR TITLE
Add JWT authentication endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ npm start
 
 ### Endpoints Principais
 
+#### Autenticação
+- `POST /api/auth/register` - Registrar novo usuário
+- `POST /api/auth/login` - Autenticar e obter token JWT
+- `GET /api/auth/me` - Obter dados do usuário autenticado
+
 #### Tenants
 - `POST /api/tenants` - Criar novo tenant
 - `GET /api/tenants/:id` - Buscar tenant

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,0 +1,116 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { User, Tenant } = require('../models');
+
+const generateToken = (user) => {
+  return jwt.sign({ userId: user.id }, process.env.JWT_SECRET, {
+    expiresIn: '1h'
+  });
+};
+
+const register = async (req, res) => {
+  try {
+    const { tenant_id, email, password, name, role } = req.body;
+
+    if (!tenant_id || !email || !password || !name) {
+      return res.status(400).json({ error: 'tenant_id, email, senha e nome são obrigatórios' });
+    }
+
+    const tenant = await Tenant.findByPk(tenant_id);
+    if (!tenant) {
+      return res.status(404).json({ error: 'Tenant não encontrado' });
+    }
+
+    const password_hash = await bcrypt.hash(password, 10);
+
+    const user = await User.create({
+      tenant_id,
+      email,
+      name,
+      role: role || 'member',
+      password_hash
+    });
+
+    const token = generateToken(user);
+
+    res.status(201).json({
+      token,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        tenant_id: user.tenant_id
+      }
+    });
+  } catch (error) {
+    console.error('Erro ao registrar usuário:', error);
+
+    if (error.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).json({ error: 'Email já cadastrado' });
+    }
+
+    res.status(500).json({ error: 'Erro interno do servidor ao registrar usuário' });
+  }
+};
+
+const login = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      return res.status(400).json({ error: 'Email e senha são obrigatórios' });
+    }
+
+    const user = await User.findOne({
+      where: { email },
+      include: [{ model: Tenant, as: 'tenant' }]
+    });
+
+    if (!user || !user.is_active) {
+      return res.status(401).json({ error: 'Credenciais inválidas' });
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.password_hash || '');
+    if (!isPasswordValid) {
+      return res.status(401).json({ error: 'Credenciais inválidas' });
+    }
+
+    const token = generateToken(user);
+
+    res.json({
+      token,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        tenant_id: user.tenant_id
+      }
+    });
+  } catch (error) {
+    console.error('Erro ao autenticar usuário:', error);
+    res.status(500).json({ error: 'Erro interno do servidor ao autenticar usuário' });
+  }
+};
+
+const me = (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Autenticação requerida' });
+  }
+
+  res.json({
+    id: req.user.id,
+    email: req.user.email,
+    name: req.user.name,
+    role: req.user.role,
+    tenant_id: req.user.tenant_id
+  });
+};
+
+module.exports = {
+  register,
+  login,
+  me
+};
+

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const { register, login, me } = require('../controllers/authController');
+const { authenticateToken } = require('../middleware/auth');
+
+router.post('/register', register);
+router.post('/login', login);
+router.get('/me', authenticateToken, me);
+
+module.exports = router;
+

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const tenantRoutes = require('./routes/tenants');
 const billingRoutes = require('./routes/billing');
 const seatRoutes = require('./routes/seats');
 const webhookRoutes = require('./routes/webhook');
+const authRoutes = require('./routes/auth');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -38,6 +39,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/api/tenants', tenantRoutes);
 app.use('/api/billing', billingRoutes);
 app.use('/api/seats', seatRoutes);
+app.use('/api/auth', authRoutes);
 
 // Rota de health check
 app.get('/health', (req, res) => {
@@ -58,7 +60,8 @@ app.get('/', (req, res) => {
       tenants: '/api/tenants',
       billing: '/api/billing',
       seats: '/api/seats',
-      webhook: '/api/stripe/webhook'
+      webhook: '/api/stripe/webhook',
+      auth: '/api/auth'
     }
   });
 });


### PR DESCRIPTION
## Summary
- add controller and routes for registering and logging in users with JWT tokens
- expose `/api/auth` endpoints and document them in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e4f046448329a9942785239c6937