### PR TITLE
Refatora exports e associações dos models

### DIFF
--- a/models/AuditBillingEvent.js
+++ b/models/AuditBillingEvent.js
@@ -1,34 +1,32 @@
-const { DataTypes } = require('sequelize');
-const sequelize = require('../config/database');
+module.exports = (sequelize, DataTypes) => {
+  const AuditBillingEvent = sequelize.define('AuditBillingEvent', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    type: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    payload_json: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    processed_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    stripe_event_id: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      unique: true,
+    },
+  }, {
+    tableName: 'audit_billing_events',
+    timestamps: true,
+    underscored: true,
+  });
 
-const AuditBillingEvent = sequelize.define('AuditBillingEvent', {
-  id: {
-    type: DataTypes.UUID,
-    defaultValue: DataTypes.UUIDV4,
-    primaryKey: true
-  },
-  type: {
-    type: DataTypes.STRING(255),
-    allowNull: false
-  },
-  payload_json: {
-    type: DataTypes.JSONB,
-    allowNull: false
-  },
-  processed_at: {
-    type: DataTypes.DATE,
-    allowNull: true
-  },
-  stripe_event_id: {
-    type: DataTypes.STRING(255),
-    allowNull: true,
-    unique: true
-  }
-}, {
-  tableName: 'audit_billing_events',
-  timestamps: true,
-  underscored: true
-});
-
-module.exports = AuditBillingEvent;
-
+  return AuditBillingEvent;
+};

--- a/models/Clientes.js
+++ b/models/Clientes.js
@@ -1,5 +1,5 @@
-module.exports = (Sequelize, DataTypes) => {
-  const Clientes = Sequelize.define("Clientes", {
+module.exports = (sequelize, DataTypes) => {
+  const Clientes = sequelize.define("Clientes", {
     id_clientee: {
       type: DataTypes.INTEGER,
       primaryKey: true,
@@ -53,12 +53,12 @@ module.exports = (Sequelize, DataTypes) => {
     created_at: {
       type: DataTypes.DATE,
       allowNull: false,
-      defaultValue: Sequelize.NOW
+      defaultValue: DataTypes.NOW
     },
     updated_at: {
       type: DataTypes.DATE,
       allowNull: false,
-      defaultValue: Sequelize.NOW
+      defaultValue: DataTypes.NOW
     },
     deleted_at: {
       type: DataTypes.DATE,

--- a/models/Eventos.js
+++ b/models/Eventos.js
@@ -1,4 +1,4 @@
-module.exports = function (sequelize, DataTypes) {
+module.exports = (sequelize, DataTypes) => {
     const Eventos = sequelize.define("Eventos", {
         id_evento: {
             type: DataTypes.INTEGER,
@@ -32,7 +32,6 @@ module.exports = function (sequelize, DataTypes) {
             allowNull: true
         }
     }, {
-        sequelize,
         tableName: 'eventos',
         modelName: 'Eventos',
         paranoid: true,  // Modo paranoia ativado para soft deletes usando o campo "deleted_at"

--- a/models/Subscription.js
+++ b/models/Subscription.js
@@ -1,47 +1,52 @@
-const { DataTypes } = require('sequelize');
-const sequelize = require('../config/database');
+module.exports = (sequelize, DataTypes) => {
+  const Subscription = sequelize.define('Subscription', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    tenant_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'tenants',
+        key: 'id',
+      },
+    },
+    stripe_subscription_id: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      unique: true,
+    },
+    stripe_price_id: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    },
+    status: {
+      type: DataTypes.ENUM('active', 'trialing', 'canceled', 'unpaid', 'past_due', 'incomplete'),
+      allowNull: false,
+    },
+    current_period_end: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  }, {
+    tableName: 'subscriptions',
+    timestamps: true,
+    underscored: true,
+  });
 
-const Subscription = sequelize.define('Subscription', {
-  id: {
-    type: DataTypes.UUID,
-    defaultValue: DataTypes.UUIDV4,
-    primaryKey: true
-  },
-  tenant_id: {
-    type: DataTypes.UUID,
-    allowNull: false,
-    references: {
-      model: 'tenants',
-      key: 'id'
-    }
-  },
-  stripe_subscription_id: {
-    type: DataTypes.STRING(255),
-    allowNull: false,
-    unique: true
-  },
-  stripe_price_id: {
-    type: DataTypes.STRING(255),
-    allowNull: false
-  },
-  quantity: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    defaultValue: 1
-  },
-  status: {
-    type: DataTypes.ENUM('active', 'trialing', 'canceled', 'unpaid', 'past_due', 'incomplete'),
-    allowNull: false
-  },
-  current_period_end: {
-    type: DataTypes.DATE,
-    allowNull: true
-  }
-}, {
-  tableName: 'subscriptions',
-  timestamps: true,
-  underscored: true
-});
+  Subscription.associate = (models) => {
+    Subscription.belongsTo(models.Tenant, {
+      foreignKey: 'tenant_id',
+      as: 'tenant',
+    });
+  };
 
-module.exports = Subscription;
-
+  return Subscription;
+};

--- a/models/Tenant.js
+++ b/models/Tenant.js
@@ -1,30 +1,39 @@
-const { DataTypes } = require('sequelize');
-const sequelize = require('../config/database');
+module.exports = (sequelize, DataTypes) => {
+  const Tenant = sequelize.define('Tenant', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    stripe_customer_id: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      unique: true,
+    },
+    status_billing: {
+      type: DataTypes.ENUM('active', 'past_due', 'canceled', 'trialing', 'incomplete'),
+      defaultValue: 'incomplete',
+    },
+  }, {
+    tableName: 'tenants',
+    timestamps: true,
+    underscored: true,
+  });
 
-const Tenant = sequelize.define('Tenant', {
-  id: {
-    type: DataTypes.UUID,
-    defaultValue: DataTypes.UUIDV4,
-    primaryKey: true
-  },
-  name: {
-    type: DataTypes.STRING(255),
-    allowNull: false
-  },
-  stripe_customer_id: {
-    type: DataTypes.STRING(255),
-    allowNull: true,
-    unique: true
-  },
-  status_billing: {
-    type: DataTypes.ENUM('active', 'past_due', 'canceled', 'trialing', 'incomplete'),
-    defaultValue: 'incomplete'
-  }
-}, {
-  tableName: 'tenants',
-  timestamps: true,
-  underscored: true
-});
+  Tenant.associate = (models) => {
+    Tenant.hasMany(models.Subscription, {
+      foreignKey: 'tenant_id',
+      as: 'subscriptions',
+    });
+    Tenant.hasMany(models.User, {
+      foreignKey: 'tenant_id',
+      as: 'users',
+    });
+  };
 
-module.exports = Tenant;
-
+  return Tenant;
+};

--- a/models/User.js
+++ b/models/User.js
@@ -1,49 +1,68 @@
-const { DataTypes } = require('sequelize');
-const sequelize = require('../config/database');
+module.exports = (sequelize, DataTypes) => {
+  const User = sequelize.define('User', {
+    id_usuario: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    tenant_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'tenants',
+        key: 'id',
+      },
+    },
+    email: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true,
+      },
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    role: {
+      type: DataTypes.ENUM('admin', 'member'),
+      defaultValue: 'member',
+    },
+    is_active: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true,
+    },
+    password_hash: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+  }, {
+    tableName: 'users',
+    timestamps: true,
+    underscored: true,
+  });
 
-const User = sequelize.define('User', {
-  id_usuario: {
-    type: DataTypes.UUID,
-    defaultValue: DataTypes.UUIDV4,
-    primaryKey: true
-  },
-  tenant_id: {
-    type: DataTypes.UUID,
-    allowNull: false,
-    references: {
-      model: 'tenants',
-      key: 'id'
-    }
-  },
-  email: {
-    type: DataTypes.STRING(255),
-    allowNull: false,
-    unique: true,
-    validate: {
-      isEmail: true
-    }
-  },
-  name: {
-    type: DataTypes.STRING(255),
-    allowNull: false
-  },
-  role: {
-    type: DataTypes.ENUM('admin', 'member'),
-    defaultValue: 'member'
-  },
-  is_active: {
-    type: DataTypes.BOOLEAN,
-    defaultValue: true
-  },
-  password_hash: {
-    type: DataTypes.STRING(255),
-    allowNull: true
-  }
-}, {
-  tableName: 'users',
-  timestamps: true,
-  underscored: true
-});
+  User.associate = (models) => {
+    User.belongsTo(models.Tenant, {
+      foreignKey: 'tenant_id',
+      as: 'tenant',
+    });
+    User.hasMany(models.Clientes, {
+      foreignKey: 'id_usuario',
+      as: 'clientes',
+    });
+    User.hasMany(models.EventosUsuarioCliente, {
+      foreignKey: 'id_usuario',
+      as: 'eventosClientes',
+    });
+    User.belongsToMany(models.Clientes, {
+      through: models.EventosUsuarioCliente,
+      foreignKey: 'id_usuario',
+      otherKey: 'id_cliente',
+      as: 'clientesEventos',
+    });
+  };
 
-module.exports = User;
-
+  return User;
+};


### PR DESCRIPTION
## Summary
- Padroniza todos os models para o formato `module.exports = (sequelize, DataTypes) => {...}`
- Move definições de associações para dentro dos respectivos models

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a50e8ce3d8832993d109c7379febc2