### PR TITLE
Remove automatic sync and add database initialization migration

### DIFF
--- a/migrations/init.js
+++ b/migrations/init.js
@@ -1,0 +1,13 @@
+const { sequelize } = require('../models');
+
+(async () => {
+  try {
+    await sequelize.sync({ force: true });
+    console.log('✅ Banco de dados inicializado com sucesso.');
+    await sequelize.close();
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Falha ao inicializar o banco de dados:', error);
+    process.exit(1);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "nodemon server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "migrate": "node migrations/init.js"
   },
   "keywords": [
     "saas",

--- a/server.js
+++ b/server.js
@@ -107,12 +107,6 @@ const startServer = async () => {
     await sequelize.authenticate();
     console.log('✅ Conexão com o banco de dados estabelecida com sucesso.');
 
-    // Sincronizar modelos (criar tabelas se não existirem)
-    if (process.env.NODE_ENV === 'development') {
-      await sequelize.sync({ alter: true });
-      console.log('✅ Modelos sincronizados com o banco de dados.');
-    }
-
     // Iniciar servidor
     app.listen(PORT, '0.0.0.0', () => {
       console.log(`🚀 Servidor rodando na porta ${PORT}`);


### PR DESCRIPTION
## Summary
- remove sequelize model sync from server startup
- add migration script to initialize database schema
- expose npm script `migrate` for running the migration

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run migrate` *(fails: SequelizeConnectionRefusedError: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68abc07f7f4883299aecaccf3b3e5314