### PR TITLE
feat: add queue jobs with redis and bullmq

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ SMTP_PASS=senha_gerada_no_mailgun
 SMTP_FROM="Converto API <no-reply@SEU_DOMINIO.com>"
 SMTP_SECURE=false
 
+# Redis
+REDIS_URL=redis://localhost:6379
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ cp .env.example .env
    - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`
    - `SMTP_FROM` (remetente padrão) e `SMTP_SECURE` (`true` para TLS)
 
+7. Configure o Redis (veja `tutorial-redis-local.md` para desenvolvimento ou `tutorial-redis-pm2.md` para produção) e ajuste `REDIS_URL` no `.env`
+
 ## Execução
 
 ### Desenvolvimento
@@ -113,6 +115,13 @@ npm start
 
 #### Webhook
 - `POST /api/stripe/webhook` - Webhook do Stripe
+
+#### Jobs
+- `POST /api/jobs/import-clients` - Criar job para importação de clientes
+- `POST /api/jobs/export-clients` - Criar job para exportação de clientes
+- `GET /api/jobs/:queue/:id` - Consultar status do job
+- `DELETE /api/jobs/:queue/:id` - Cancelar job
+- `GET /admin/queues` - Painel de acompanhamento dos jobs
 
 ## Configuração do Stripe
 

--- a/controllers/jobsController.js
+++ b/controllers/jobsController.js
@@ -1,0 +1,53 @@
+const importQueue = require('../queues/importClientsQueue');
+const exportQueue = require('../queues/exportClientsQueue');
+
+const queues = {
+  import: importQueue,
+  export: exportQueue,
+};
+
+exports.importClients = async (req, res) => {
+  try {
+    const job = await importQueue.add('import', req.body || {});
+    res.json({ id: job.id });
+  } catch (err) {
+    console.error('importClients job error', err);
+    res.status(500).json({ error: 'Erro ao adicionar job' });
+  }
+};
+
+exports.exportClients = async (req, res) => {
+  try {
+    const job = await exportQueue.add('export', req.body || {});
+    res.json({ id: job.id });
+  } catch (err) {
+    console.error('exportClients job error', err);
+    res.status(500).json({ error: 'Erro ao adicionar job' });
+  }
+};
+
+exports.getJobStatus = async (req, res) => {
+  const { queue, id } = req.params;
+  const q = queues[queue];
+  if (!q) return res.status(404).json({ error: 'Fila não encontrada' });
+  const job = await q.getJob(id);
+  if (!job) return res.status(404).json({ error: 'Job não encontrado' });
+  const state = await job.getState();
+  res.json({
+    id: job.id,
+    state,
+    progress: job.progress,
+    data: job.data,
+    result: job.returnvalue || null,
+  });
+};
+
+exports.cancelJob = async (req, res) => {
+  const { queue, id } = req.params;
+  const q = queues[queue];
+  if (!q) return res.status(404).json({ error: 'Fila não encontrada' });
+  const job = await q.getJob(id);
+  if (!job) return res.status(404).json({ error: 'Job não encontrado' });
+  await job.remove();
+  res.json({ success: true });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@bull-board/api": "^6.12.7",
+        "@bull-board/express": "^6.12.7",
         "bcryptjs": "^3.0.2",
+        "bullmq": "^5.58.2",
         "cors": "^2.8.5",
         "csv-parser": "^3.2.0",
         "dotenv": "^17.2.1",
@@ -17,6 +20,7 @@
         "express": "^4.21.1",
         "express-rate-limit": "^8.0.1",
         "helmet": "^8.1.0",
+        "ioredis": "^5.7.0",
         "jsonwebtoken": "^9.0.2",
         "luxon": "^3.4.4",
         "moment-timezone": "^0.5.43",
@@ -32,6 +36,45 @@
         "nodemon": "^3.1.10",
         "sequelize-cli": "^6.6.3"
       }
+    },
+    "node_modules/@bull-board/api": {
+      "version": "6.12.7",
+      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-6.12.7.tgz",
+      "integrity": "sha512-mI/akvhI937/IPB9+l2NN18Vd+RivCoNLIJ3h3ZxNrp3xetjX5R90l/wuHt5SG837sLkChgMhRVA2mJAiGypJA==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-info": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@bull-board/ui": "6.12.7"
+      }
+    },
+    "node_modules/@bull-board/express": {
+      "version": "6.12.7",
+      "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-6.12.7.tgz",
+      "integrity": "sha512-KPzOQSk8HRg5sTO2zuAl8b55YBy4ljxZDs+vMBEE8J2yhER0Kx09sZwWfj8DfIK58+qSriEzgfNWn7loFTawTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bull-board/api": "6.12.7",
+        "@bull-board/ui": "6.12.7",
+        "ejs": "^3.1.10",
+        "express": "^4.21.1 || ^5.0.0"
+      }
+    },
+    "node_modules/@bull-board/ui": {
+      "version": "6.12.7",
+      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.12.7.tgz",
+      "integrity": "sha512-EJvS84Ob661ASIjGH58RpKLb7upPM+kS9I7PdezS67Dtab1V8cq10E+Sb2WIvXVLaGgQU8eITiLBjgWze2uWsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bull-board/api": "6.12.7"
+      }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -50,6 +93,84 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
@@ -321,6 +442,34 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bullmq": {
+      "version": "5.58.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.58.2.tgz",
+      "integrity": "sha512-HSGtNFM8Ttzml4OHO5cy6ju0ObnDmSedXJwpSUCFSDXR6l9MQe5CQCs/FzAb6Ac9EXYIvvF20UMV+C1OVDW39w==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.9.0",
+        "ioredis": "^5.4.1",
+        "msgpackr": "^1.11.2",
+        "node-abort-controller": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -475,6 +624,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -572,6 +730,18 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -616,6 +786,15 @@
         }
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -633,6 +812,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -1287,6 +1476,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -1511,10 +1724,22 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -1731,6 +1956,37 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
+      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1738,6 +1994,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/nodemailer": {
@@ -2140,6 +2417,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-info": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redis-info/-/redis-info-3.1.0.tgz",
+      "integrity": "sha512-ER4L9Sh/vm63DkIE0bkSjxluQlioBiBgf5w1UuldaW/3vPcecdljVDisZhmnCMvsxHNiARTTDDHGg9cGwTfrKg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2517,6 +2824,12 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2713,6 +3026,12 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "migrar": "npx sequelize db:migrate",
     "migration": "sequelize migration:create --name",
-    "migrate:reset-token": "node migrations/add-reset-token-fields.js"
+    "migrate:reset-token": "node migrations/add-reset-token-fields.js",
+    "queue:workers": "node queues/workers/index.js"
   },
   "keywords": [
     "saas",
@@ -21,7 +22,10 @@
   "license": "MIT",
   "description": "API SaaS multi-tenant com integração Stripe para modelo per-seat",
   "dependencies": {
+    "@bull-board/api": "^6.12.7",
+    "@bull-board/express": "^6.12.7",
     "bcryptjs": "^3.0.2",
+    "bullmq": "^5.58.2",
     "cors": "^2.8.5",
     "csv-parser": "^3.2.0",
     "dotenv": "^17.2.1",
@@ -29,6 +33,7 @@
     "express": "^4.21.1",
     "express-rate-limit": "^8.0.1",
     "helmet": "^8.1.0",
+    "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.2",
     "luxon": "^3.4.4",
     "moment-timezone": "^0.5.43",

--- a/postman/converto-api.postman_collection.json
+++ b/postman/converto-api.postman_collection.json
@@ -1,962 +1,1097 @@
 {
-	"info": {
-		"_postman_id": "c646a57d-1f4c-4fca-b860-f5ba591eb8b6",
-		"name": "Converto API",
-		"description": "Coleção para testar a API Converto",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21115923"
-	},
-	"item": [
-		{
-			"name": "General",
-			"item": [
-				{
-					"name": "Root",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Health",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/health",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"health"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Auth",
-			"item": [
-				{
-					"name": "Register",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"name\": \"Usuário\",\n  \"email\": \"colaborador@email.com\",\n  \"password\": \"123123\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/auth/register",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"auth",
-								"register"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Login",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"const response = pm.response.json();\r",
-									"pm.environment.set(\"bearar_token\", response.token);\r",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"email\": \"colaborador@email.com\",\n  \"password\": \"123123\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/auth/login",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"auth",
-								"login"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Me",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/auth/me",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"auth",
-								"me"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-               {
-                       "name": "Profile",
-                       "item": [
-                               {
-                                       "name": "Get Profile",
-                                       "request": {
-                                               "method": "GET",
-                                               "header": [
-                                                       { "key": "Authorization", "value": "Bearer {{token}}", "type": "text" }
-                                               ],
-                                               "url": {
-                                                       "raw": "{{base_url}}/api/profile",
-                                                       "host": ["{{base_url}}"],
-                                                       "path": ["api", "profile"]
-                                               }
-                                       },
-                                       "response": []
-                               },
-                               {
-                                       "name": "Change Password",
-                                       "request": {
-                                               "method": "PUT",
-                                               "header": [
-                                                       { "key": "Content-Type", "value": "application/json" },
-                                                       { "key": "Authorization", "value": "Bearer {{token}}", "type": "text" }
-                                               ],
-                                               "body": {
-                                                       "mode": "raw",
-                                                       "raw": "{\\n  \\\"oldPassword\\\": \\\"123123\\\",\\n  \\\"newPassword\\\": \\\"novaSenha123\\\"\\n}"
-                                               },
-                                               "url": {
-                                                       "raw": "{{base_url}}/api/profile/password",
-                                                       "host": ["{{base_url}}"],
-                                                       "path": ["api", "profile", "password"]
-                                               }
-                                       },
-                                       "response": []
-                               },
-                               {
-                                       "name": "Forgot Password",
-                                       "request": {
-                                               "method": "POST",
-                                               "header": [
-                                                       { "key": "Content-Type", "value": "application/json" }
-                                               ],
-                                               "body": {
-                                                       "mode": "raw",
-                                                       "raw": "{\\n  \\\"email\\\": \\\"usuario@example.com\\\"\\n}"
-                                               },
-                                               "url": {
-                                                       "raw": "{{base_url}}/api/profile/forgot-password",
-                                                       "host": ["{{base_url}}"],
-                                                       "path": ["api", "profile", "forgot-password"]
-                                               }
-                                       },
-                                       "response": []
-                               },
-                               {
-                                       "name": "Reset Password",
-                                       "request": {
-                                               "method": "POST",
-                                               "header": [
-                                                       { "key": "Content-Type", "value": "application/json" }
-                                               ],
-                                               "body": {
-                                                       "mode": "raw",
-                                                       "raw": "{\\n  \\\"token\\\": \\\"<token>\\\",\\n  \\\"newPassword\\\": \\\"novaSenha123\\\"\\n}"
-                                               },
-                                               "url": {
-                                                       "raw": "{{base_url}}/api/profile/reset-password",
-                                                       "host": ["{{base_url}}"],
-                                                       "path": ["api", "profile", "reset-password"]
-                                               }
-                                       },
-                                       "response": []
-                               }
-                       ]
-               },
-               {
-                       "name": "Tenants",
-                       "item": [
-				{
-					"name": "Create Tenant",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"const response = pm.response.json();\r",
-									"pm.environment.set(\"tenant_id\", response.id);\r",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Empresa Exemplo\",\n  \"email\": \"colaborador@email.com\",\n  \"enterprise_name\": \"Empresa Exemplo\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/tenants",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"tenants"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Tenant",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/tenants/{{tenant_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"tenants",
-								"{{tenant_id}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update Tenant",
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Empresa Atualizada\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/tenants/{{tenant_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"tenants",
-								"{{tenant_id}}"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Enterprises",
-			"item": [
-				{
-					"name": "Create Enterprise",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Nova Empresa\",\n  \"tenant_id\": \"{{tenant_id}}\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/enterprises",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"enterprises"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "List Enterprises",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/enterprises",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"enterprises"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Enterprise",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/enterprises/{{enterprise_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"enterprises",
-								"{{enterprise_id}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update Enterprise",
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Empresa Atualizada\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/enterprises/{{enterprise_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"enterprises",
-								"{{enterprise_id}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Enterprise",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/enterprises/{{enterprise_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"enterprises",
-								"{{enterprise_id}}"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Billing",
-			"item": [
-				{
-					"name": "Create Checkout Session",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"price_id\": \"price_xxxx\",\n  \"seatCountInicial\": 5,\n  \"success_url\": \"https://app.com/success\",\n  \"cancel_url\": \"https://app.com/cancel\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/billing/checkout",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"billing",
-								"checkout"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Portal Session",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"return_url\": \"https://app.com/account\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/billing/portal",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"billing",
-								"portal"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Subscription Status",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/billing/status/{{tenant_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"billing",
-								"status",
-								"{{tenant_id}}"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Seats",
-			"item": [
-				{
-					"name": "Sync Seats",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tenant_id\": \"{{tenant_id}}\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/seats/sync",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"seats",
-								"sync"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Seat Usage",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/seats/usage/{{tenant_id}}",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"seats",
-								"usage",
-								"{{tenant_id}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Add Seat",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"user_id\": \"{{user_id}}\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/seats/add",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"seats",
-								"add"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Remove Seat",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"user_id\": \"{{user_id}}\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/seats/remove",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"seats",
-								"remove"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Clientes",
-			"item": [
-				{
-					"name": "Criar Cliente",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"nome\": \"Cliente Exemplo\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/clientes",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"clientes"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Listar Clientes",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/clientes",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"clientes"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "CRM",
-			"item": [
-				{
-					"name": "Pesquisar Contatos",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/crm/contatos?numero=5511999999999",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"crm",
-								"contatos"
-							],
-							"query": [
-								{
-									"key": "numero",
-									"value": "5511999999999"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-                },
+  "info": {
+    "_postman_id": "c646a57d-1f4c-4fca-b860-f5ba591eb8b6",
+    "name": "Converto API",
+    "description": "Coleção para testar a API Converto",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "21115923"
+  },
+  "item": [
+    {
+      "name": "General",
+      "item": [
+        {
+          "name": "Root",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                ""
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Health",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/health",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Register",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"name\": \"Usuário\",\n  \"email\": \"colaborador@email.com\",\n  \"password\": \"123123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/auth/register",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "register"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const response = pm.response.json();\r",
+                  "pm.environment.set(\"bearar_token\", response.token);\r",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"colaborador@email.com\",\n  \"password\": \"123123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Me",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/auth/me",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "auth",
+                "me"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Profile",
+      "item": [
+        {
+          "name": "Get Profile",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/profile",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "profile"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Change Password",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\\n  \\\"oldPassword\\\": \\\"123123\\\",\\n  \\\"newPassword\\\": \\\"novaSenha123\\\"\\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/profile/password",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "profile",
+                "password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Forgot Password",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\\n  \\\"email\\\": \\\"usuario@example.com\\\"\\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/profile/forgot-password",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "profile",
+                "forgot-password"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Reset Password",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\\n  \\\"token\\\": \\\"<token>\\\",\\n  \\\"newPassword\\\": \\\"novaSenha123\\\"\\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/profile/reset-password",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "profile",
+                "reset-password"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Tenants",
+      "item": [
+        {
+          "name": "Create Tenant",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const response = pm.response.json();\r",
+                  "pm.environment.set(\"tenant_id\", response.id);\r",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Empresa Exemplo\",\n  \"email\": \"colaborador@email.com\",\n  \"enterprise_name\": \"Empresa Exemplo\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/tenants",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "tenants"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Tenant",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/tenants/{{tenant_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "tenants",
+                "{{tenant_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Tenant",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Empresa Atualizada\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/tenants/{{tenant_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "tenants",
+                "{{tenant_id}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Enterprises",
+      "item": [
+        {
+          "name": "Create Enterprise",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Nova Empresa\",\n  \"tenant_id\": \"{{tenant_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/enterprises",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "enterprises"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Enterprises",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/enterprises",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "enterprises"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Enterprise",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/enterprises/{{enterprise_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "enterprises",
+                "{{enterprise_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Enterprise",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Empresa Atualizada\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/enterprises/{{enterprise_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "enterprises",
+                "{{enterprise_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Enterprise",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/enterprises/{{enterprise_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "enterprises",
+                "{{enterprise_id}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Billing",
+      "item": [
+        {
+          "name": "Create Checkout Session",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"price_id\": \"price_xxxx\",\n  \"seatCountInicial\": 5,\n  \"success_url\": \"https://app.com/success\",\n  \"cancel_url\": \"https://app.com/cancel\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/billing/checkout",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "billing",
+                "checkout"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Portal Session",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"return_url\": \"https://app.com/account\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/billing/portal",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "billing",
+                "portal"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Subscription Status",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/billing/status/{{tenant_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "billing",
+                "status",
+                "{{tenant_id}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Seats",
+      "item": [
+        {
+          "name": "Sync Seats",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/seats/sync",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "seats",
+                "sync"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Seat Usage",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/seats/usage/{{tenant_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "seats",
+                "usage",
+                "{{tenant_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Add Seat",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"user_id\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/seats/add",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "seats",
+                "add"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Remove Seat",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tenant_id\": \"{{tenant_id}}\",\n  \"user_id\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/seats/remove",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "seats",
+                "remove"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Clientes",
+      "item": [
+        {
+          "name": "Criar Cliente",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"nome\": \"Cliente Exemplo\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/clientes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "clientes"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Listar Clientes",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/clientes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "clientes"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "CRM",
+      "item": [
+        {
+          "name": "Pesquisar Contatos",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/crm/contatos?numero=5511999999999",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "crm",
+                "contatos"
+              ],
+              "query": [
                 {
-                        "name": "Sugestões",
-                        "item": [
-                                {
-                                        "name": "Enviar Sugestão",
-                                        "request": {
-                                                "method": "POST",
-                                                "header": [
-                                                        {
-                                                                "key": "Authorization",
-                                                                "value": "Bearer {{token}}"
-                                                        },
-                                                        {
-                                                                "key": "Content-Type",
-                                                                "value": "application/json"
-                                                        }
-                                                ],
-                                                "body": {
-                                                        "mode": "raw",
-                                                        "raw": "{\n  \"tipo\": \"Sugestão\",\n  \"mensagem\": \"Texto da sugestão\"\n}"
-                                                },
-                                                "url": {
-                                                        "raw": "{{base_url}}/api/sugestoes",
-                                                        "host": [
-                                                                "{{base_url}}"
-                                                        ],
-                                                        "path": [
-                                                                "api",
-                                                                "sugestoes"
-                                                        ]
-                                                }
-                                        },
-                                        "response": []
-                                },
-                                {
-                                        "name": "Listar Sugestões (Moderador)",
-                                        "request": {
-                                                "method": "GET",
-                                                "description": "Somente moderadores podem acessar.",
-                                                "header": [
-                                                        {
-                                                                "key": "Authorization",
-                                                                "value": "Bearer {{token}}"
-                                                        }
-                                                ],
-                                                "url": {
-                                                        "raw": "{{base_url}}/api/sugestoes",
-                                                        "host": [
-                                                                "{{base_url}}"
-                                                        ],
-                                                        "path": [
-                                                                "api",
-                                                                "sugestoes"
-                                                        ]
-                                                }
-                                        },
-                                        "response": []
-                                }
-                        ]
-                },
-                {
-                        "name": "Usuarios",
-			"item": [
-				{
-					"name": "Criar Usuário",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Novo Usuário\",\n  \"email\": \"novo@example.com\",\n  \"password\": \"123456\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/usuarios",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"usuarios"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Listar Usuários",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"url": {
-							"raw": "{{base_url}}/api/usuarios",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"usuarios"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Stripe",
-			"item": [
-				{
-					"name": "Webhook",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"type\": \"test.event\"\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/api/stripe/webhook",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"stripe",
-								"webhook"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		}
-	],
-	"auth": {
-		"type": "bearer",
-		"bearer": [
-			{
-				"key": "token",
-				"value": "{{bearar_token}}",
-				"type": "string"
-			}
-		]
-	},
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		}
-	]
+                  "key": "numero",
+                  "value": "5511999999999"
+                }
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Sugestões",
+      "item": [
+        {
+          "name": "Enviar Sugestão",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tipo\": \"Sugestão\",\n  \"mensagem\": \"Texto da sugestão\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/sugestoes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "sugestoes"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Listar Sugestões (Moderador)",
+          "request": {
+            "method": "GET",
+            "description": "Somente moderadores podem acessar.",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/sugestoes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "sugestoes"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Usuarios",
+      "item": [
+        {
+          "name": "Criar Usuário",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Novo Usuário\",\n  \"email\": \"novo@example.com\",\n  \"password\": \"123456\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/usuarios",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "usuarios"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Listar Usuários",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/usuarios",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "usuarios"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Stripe",
+      "item": [
+        {
+          "name": "Webhook",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"test.event\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/stripe/webhook",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "stripe",
+                "webhook"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Jobs",
+      "item": [
+        {
+          "name": "Import Clients",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/jobs/import-clients",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "jobs",
+                "import-clients"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Export Clients",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/jobs/export-clients",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "jobs",
+                "export-clients"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Job Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/jobs/import/:id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "jobs",
+                "import",
+                ":id"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Cancel Job",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/jobs/import/:id",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "jobs",
+                "import",
+                ":id"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{bearar_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
 }

--- a/queues/exportClientsQueue.js
+++ b/queues/exportClientsQueue.js
@@ -1,0 +1,6 @@
+const { Queue } = require('bullmq');
+const connection = require('../services/redis');
+
+const exportClientsQueue = new Queue('export-clients', { connection });
+
+module.exports = exportClientsQueue;

--- a/queues/importClientsQueue.js
+++ b/queues/importClientsQueue.js
@@ -1,0 +1,6 @@
+const { Queue } = require('bullmq');
+const connection = require('../services/redis');
+
+const importClientsQueue = new Queue('import-clients', { connection });
+
+module.exports = importClientsQueue;

--- a/queues/workers/exportClientsWorker.js
+++ b/queues/workers/exportClientsWorker.js
@@ -1,0 +1,7 @@
+const { Worker } = require('bullmq');
+const connection = require('../../services/redis');
+
+module.exports = new Worker('export-clients', async job => {
+  // TODO: implement export logic
+  console.log(`Processing export job ${job.id}`, job.data);
+}, { connection });

--- a/queues/workers/importClientsWorker.js
+++ b/queues/workers/importClientsWorker.js
@@ -1,0 +1,7 @@
+const { Worker } = require('bullmq');
+const connection = require('../../services/redis');
+
+module.exports = new Worker('import-clients', async job => {
+  // TODO: implement import logic
+  console.log(`Processing import job ${job.id}`, job.data);
+}, { connection });

--- a/queues/workers/index.js
+++ b/queues/workers/index.js
@@ -1,0 +1,2 @@
+require('./importClientsWorker');
+require('./exportClientsWorker');

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const jobsController = require('../controllers/jobsController');
+
+router.post('/import-clients', jobsController.importClients);
+router.post('/export-clients', jobsController.exportClients);
+router.get('/:queue/:id', jobsController.getJobStatus);
+router.delete('/:queue/:id', jobsController.cancelJob);
+
+module.exports = router;

--- a/services/redis.js
+++ b/services/redis.js
@@ -1,0 +1,5 @@
+const { Redis } = require('ioredis');
+
+const connection = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+
+module.exports = connection;

--- a/tutorial-redis-local.md
+++ b/tutorial-redis-local.md
@@ -1,0 +1,38 @@
+# Tutorial: Instalando e executando o Redis localmente
+
+Este guia mostra como configurar o Redis para desenvolvimento local sem PM2.
+
+## 1. Instalar o Redis
+
+No Ubuntu/Debian:
+```bash
+sudo apt update
+sudo apt install redis-server -y
+```
+
+No macOS (Homebrew):
+```bash
+brew install redis
+```
+
+## 2. Iniciar o servidor
+
+Execute o comando abaixo para iniciar o Redis no terminal:
+```bash
+redis-server
+```
+O processo ficará em primeiro plano. Deixe este terminal aberto enquanto estiver usando o Redis.
+
+## 3. Testar a conexão
+
+Em outro terminal, rode:
+```bash
+redis-cli ping
+# Deve responder com PONG
+```
+
+## 4. Encerrar o servidor
+
+Use `Ctrl+C` no terminal onde o Redis está rodando para parar o serviço.
+
+Pronto! Agora o Redis está configurado para uso local no desenvolvimento.

--- a/tutorial-redis-pm2.md
+++ b/tutorial-redis-pm2.md
@@ -1,0 +1,35 @@
+# Tutorial: Instalando e executando Redis com PM2
+
+Este passo a passo mostra como instalar o Redis e mantê-lo ativo usando o [PM2](https://pm2.keymetrics.io/).
+
+## 1. Instalar Redis
+```bash
+sudo apt update
+sudo apt install redis-server -y
+```
+
+## 2. Testar serviço
+```bash
+redis-cli ping
+# Deve responder com PONG
+```
+
+## 3. Instalar PM2 (caso ainda não tenha)
+```bash
+npm install -g pm2
+```
+
+## 4. Rodar o Redis com PM2
+```bash
+pm2 start `which redis-server` --name redis
+pm2 save
+```
+
+## 5. Gerenciar
+```bash
+pm2 status
+pm2 logs redis
+pm2 stop redis
+```
+
+Assim o Redis fica ativo em segundo plano e reinicia automaticamente após reboot.


### PR DESCRIPTION
## Summary
- setup Redis BullMQ queues for client import and export jobs
- expose job management routes and bull-board dashboard
- document Redis/PM2 and local setup tutorials and queue API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c793681c8329b81d0148d71d56ff