### PR TITLE
Move client import to background job

### DIFF
--- a/controllers/jobsController.js
+++ b/controllers/jobsController.js
@@ -8,7 +8,15 @@ const queues = {
 
 exports.importClients = async (req, res) => {
   try {
-    const job = await importQueue.add('import', req.body || {});
+    if (!req.files || !req.files.file) {
+      return res.status(400).json({ error: 'Arquivo CSV é obrigatório.' });
+    }
+    const csvFile = req.files.file;
+    const filePath = csvFile.tempFilePath;
+    const job = await importQueue.add('import', {
+      filePath,
+      enterpriseId: req.enterprise.id,
+    });
     res.json({ id: job.id });
   } catch (err) {
     console.error('importClients job error', err);

--- a/queues/workers/importClientsWorker.js
+++ b/queues/workers/importClientsWorker.js
@@ -1,7 +1,8 @@
 const { Worker } = require('bullmq');
 const connection = require('../../services/redis');
+const { importClientsFromCsv } = require('../../services/importClients');
 
 module.exports = new Worker('import-clients', async job => {
-  // TODO: implement import logic
-  console.log(`Processing import job ${job.id}`, job.data);
+  const { filePath, enterpriseId } = job.data;
+  return await importClientsFromCsv(filePath, enterpriseId);
 }, { connection });

--- a/routes/clientesRouter.js
+++ b/routes/clientesRouter.js
@@ -1,13 +1,11 @@
-
 // pedidosRouter.js
 const express = require('express');
-const clientesController = require('../controllers/clientesController')
+const clientesController = require('../controllers/clientesController');
 const eventosController = require('../controllers/eventosController');
 const { authenticateToken } = require('../middleware/auth');
 const { requireActiveSubscription } = require('../middleware/subscription');
 
 const router = express.Router();
-
 
 
 router.post('/', authenticateToken, requireActiveSubscription, clientesController.postClientes);
@@ -27,13 +25,8 @@ router.post('/dashboard/clientes-atendidos', authenticateToken, clientesControll
 router.post('/dashboard/clientes-fechados', authenticateToken, clientesController.listClientesFechados);
 router.post('/dashboard/eventos-marcados', authenticateToken, clientesController.listEventosMarcados);
 
-
-
-
 router.get('/', authenticateToken, requireActiveSubscription, clientesController.getClientes);
 router.get('/filtros', authenticateToken, requireActiveSubscription, clientesController.getFiltros);
 router.delete('/:id', authenticateToken, requireActiveSubscription, clientesController.deleteCliente);
-router.post('/bulk', authenticateToken, requireActiveSubscription, clientesController.postBulkClientes);
-
 
 module.exports = router;

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const jobsController = require('../controllers/jobsController');
+const { authenticateToken } = require('../middleware/auth');
+const { requireActiveSubscription } = require('../middleware/subscription');
 
-router.post('/import-clients', jobsController.importClients);
-router.post('/export-clients', jobsController.exportClients);
+router.post('/import-clients', authenticateToken, requireActiveSubscription, jobsController.importClients);
+router.post('/export-clients', authenticateToken, requireActiveSubscription, jobsController.exportClients);
 router.get('/:queue/:id', jobsController.getJobStatus);
 router.delete('/:queue/:id', jobsController.cancelJob);
 

--- a/services/importClients.js
+++ b/services/importClients.js
@@ -1,0 +1,52 @@
+const csvParser = require('csv-parser');
+const fs = require('fs');
+const models = require('../models');
+const { formataTexto } = require('../utils/utils');
+
+async function importClientsFromCsv(filePath, enterpriseId) {
+  const linhas = await new Promise((resolve, reject) => {
+    const resultados = [];
+    fs.createReadStream(filePath)
+      .pipe(csvParser({
+        separator: ';',
+        mapHeaders: ({ header }) => header.trim()
+      }))
+      .on('data', row => resultados.push(row))
+      .on('end', () => resolve(resultados))
+      .on('error', err => reject(err));
+  });
+
+  const resumo = { criados: 0, atualizados: 0, pulados: 0, erros: [] };
+  for (let [i, row] of linhas.entries()) {
+    const celular = row.celular?.trim();
+    const nomeRaw = row.nome?.trim();
+    if (!celular || !nomeRaw) {
+      resumo.erros.push({ linha: i + 1, motivo: 'Falta nome ou celular' });
+      continue;
+    }
+
+    const dados = { celular, nome: formataTexto(nomeRaw), enterprise_id: enterpriseId };
+    if (row.status) dados.status = formataTexto(row.status.trim());
+    if (row.cidade) dados.cidade = formataTexto(row.cidade.trim());
+    if (row.id_usuario) dados.id_usuario = row.id_usuario;
+    if (row.indicacao) dados.indicacao = formataTexto(row.indicacao.trim());
+    if (row.campanha) dados.campanha = formataTexto(row.campanha.trim());
+    if (row.observacao) dados.observacao = formataTexto(row.observacao.trim());
+
+    const existente = await models.Clientes.findOne({
+      where: { celular, deleted_at: null, enterprise_id: enterpriseId }
+    });
+
+    if (existente) {
+      await existente.update(dados);
+      resumo.atualizados++;
+    } else {
+      await models.Clientes.create(dados);
+      resumo.criados++;
+    }
+  }
+
+  return resumo;
+}
+
+module.exports = { importClientsFromCsv };


### PR DESCRIPTION
## Summary
- Remove legacy /clientes/bulk endpoint
- Add CSV import service and use it in BullMQ worker
- Queue client import jobs via authenticated /jobs/import-clients route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d665b2cc83298170640fc89532a3